### PR TITLE
upgrade to syn 2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ fs-err = "2"
 proc-macro2 = "1"
 quote = "1"
 blake2 = "0.10"
-syn = { version = "1", optional = true, default-features = false }
+syn = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]
 baz = { path = "./tests/baz" }
-syn = { version = "1", features = ["extra-traits", "full"] }
+syn = { version = "2", features = ["extra-traits", "full"] }
 
 [features]
 default = ["syndicate"]


### PR DESCRIPTION
This PR upgrades syn to use the latest 2.x version

Among other things, this will make expander compatible with the global upgrade to syn 2.x we are doing on substrate/polkadot: https://github.com/paritytech/substrate/pull/13846