### PR TITLE
Accumulated changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,13 @@ proc-macro2 = "1"
 quote = "1"
 blake2 = "0.10"
 syn = { version = "2", optional = true, default-features = false }
+prettier-please = { version = "0.2", optional = true, default-features = false }
 
 [dev-dependencies]
 baz = { path = "./tests/baz" }
-syn = { version = "2", features = ["extra-traits", "full"] }
+syn = { version = "2", features = ["extra-traits", "parsing", "full"] }
 
 [features]
-default = ["syndicate"]
+default = ["syndicate", "pretty"]
 syndicate = ["syn"]
+pretty = ["prettier-please", "syn/parsing", "syn/full"]

--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ string to the terminal.
 > Hint: You can quickly toggle this by using `.dry(true || false)`
 
 
-# Special handling: `syn`
+# Features
+
+## Special handling: `syn`
 
 By default `expander` is built with feature `syndicate` which adds `fn maybe_write_*`
 to `struct Expander`, which aids handling of `Result<TokenStream, syn::Error>` for the
@@ -144,3 +146,10 @@ commonly used rust parsing library `syn`.
 which provides better info to the user (that's you!) than when serializing it to file, since the provided
 `span` for the `syn::Error` is printed differently - being pointed to the `compile_error!` invocation
 in the generated file is not helpful, and `rustc` can point to the `span` instead.
+
+## `rustfmt`-free formatting: `pretty`
+
+When built with feature `pretty`, the output is formatted with `prettier-please`. Note that this adds
+additional compiletime overhead and weight to the crate as a trade off not needing any host side tooling.
+
+The formatting output will, for any significant amount of lines of code, differ from the output of `rustfmt`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,15 @@ fn expand_to_file(
     verbose: bool,
 ) -> Result<TokenStream, std::io::Error> {
     let token_str = tokens.to_string();
+    #[cfg(feature = "pretty")]
+    let token_str = match syn::parse_file(&token_str) {
+        Err(e) => {
+            eprintln!("expander: failed to prettify {}: {:?}", dest.display(), e);
+            token_str
+        }
+        Ok(sf) => prettier_please::unparse(&sf),
+    };
+
     let mut bytes = token_str.as_bytes();
     let hash = <blake2::Blake2s256 as blake2::Digest>::digest(bytes);
     let shortened_hex = make_suffix(hash.as_ref());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ fn expand_to_file(
             .arg(format!("--edition={}", edition))
             .arg(&dest)
             .current_dir(cwd)
-            .spawn()?;
+            .status()?;
     }
 
     let dest = dest.display().to_string();

--- a/tests/baz/Cargo.toml
+++ b/tests/baz/Cargo.toml
@@ -14,4 +14,6 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-expander = { path = "../..", " version" = "1" }
+expander = { path = "../..", features = [
+  "pretty",
+], default-features = false }

--- a/tests/baz/lib.rs
+++ b/tests/baz/lib.rs
@@ -1,4 +1,4 @@
-use expander::{Expander, Edition};
+use expander::{Channel, Edition, Expander};
 
 #[proc_macro_attribute]
 pub fn baz(_attr: proc_macro::TokenStream, input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -13,7 +13,7 @@ fn baz2(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
 
     let expanded = Expander::new("baz")
         .add_comment("This is generated code!".to_owned())
-        .fmt(Edition::_2021)
+        .fmt_full(Channel::Stable, Edition::_2021, true)
         .write_to_out_dir(modified).expect("No IO error");
     expanded
 }


### PR DESCRIPTION
1. Closes #9
2. Adds feature to use `prettier-please` with feature `pretty` to avoid host dependencies
3. Expands on options to use `rustfmt`, to allow for acceptable failure and specifying the channel to use.