### PR TITLE
PR 2 of 2: (Draft) Full fix for FileGuard issue (issue #13), incorporating PR #14

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,43 +298,54 @@ fn expand_to_file(
             .arg(&dest)
             .current_dir(cwd);
 
-        let res = process.status();
-        match res {
-            Err(err) => {
-                if allow_failure {
-                    eprintln!(
-                        "expander: failed to format file {} due to {}",
-                        dest.display(),
-                        err
-                    );
-                } else {
-                    return Err(err);
-                }
-            }
-            Ok(exit_status) => {
-                if !exit_status.success() {
-                    let error = std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!(
-                            "rustfmt failed with exit code {} on file {}",
-                            exit_status.code().unwrap_or(-1),
-                            dest.display()
-                        ),
-                    );
-                    if allow_failure {
-                        eprintln!("expander: {}", error);
-                    } else {
-                        return Err(error);
-                    }
-                }
-            }
-        }
+        handle_rustfmt_result(process.status(), &dest, allow_failure)?;
     }
 
     let dest = dest.display().to_string();
     Ok(quote! {
         include!( #dest );
     })
+}
+
+fn handle_rustfmt_result(
+    res: std::io::Result<std::process::ExitStatus>,
+    dest: &Path,
+    allow_failure: bool,
+) -> std::io::Result<()> {
+    match res {
+        Err(err) => {
+            if allow_failure {
+                eprintln!(
+                    "expander: failed to format file {} due to {}",
+                    dest.display(),
+                    err
+                );
+                Ok(())
+            } else {
+                Err(err)
+            }
+        }
+        Ok(exit_status) => {
+            if !exit_status.success() {
+                let error = std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!(
+                        "rustfmt failed with exit code {} on file {}",
+                        exit_status.code().unwrap_or(-1),
+                        dest.display()
+                    ),
+                );
+                if allow_failure {
+                    eprintln!("expander: {}", error);
+                    Ok(())
+                } else {
+                    Err(error)
+                }
+            } else {
+                Ok(())
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,39 +253,37 @@ fn expand_to_file(
         .truncate(true)
         .open(dest.as_path())?;
 
-    // Force implicit drop of FileGuard before rustfmt to prevent intermittent partial file locking issues on Windows (os error 33)
-    {
-        let Ok(mut f) = file_guard::try_lock(f.file_mut(), file_guard::Lock::Exclusive, 0, 64)
-        else {
-            // the digest of the file will not match if the content to be written differed, hence any existing lock
-            // means we are already writing the same content to the file
-            if verbose {
-                eprintln!("expander: already in progress of writing identical content to {} by a different crate", dest.display());
-            }
-            // now actually wait until the write is complete
-            let _lock = file_guard::lock(f.file_mut(), file_guard::Lock::Exclusive, 0, 64)
-                .expect("File Lock never fails us. qed");
-
-            if verbose {
-                eprintln!("expander: lock was release, referencing");
-            }
-
-            let dest = dest.display().to_string();
-            return Ok(quote! {
-                include!( #dest );
-            });
-        };
+    let Ok(mut f) = file_guard::try_lock(f.file_mut(), file_guard::Lock::Exclusive, 0, 64) else {
+        // the digest of the file will not match if the content to be written differed, hence any existing lock
+        // means we are already writing the same content to the file
+        if verbose {
+            eprintln!("expander: already in progress of writing identical content to {} by a different crate", dest.display());
+        }
+        // now actually wait until the write is complete
+        let _lock = file_guard::lock(f.file_mut(), file_guard::Lock::Exclusive, 0, 64)
+            .expect("File Lock never fails us. qed");
 
         if verbose {
-            eprintln!("expander: writing {}", dest.display());
+            eprintln!("expander: lock was release, referencing");
         }
 
-        if let Some(comment) = comment.into() {
-            f.write_all(&mut comment.as_bytes())?;
-        }
+        let dest = dest.display().to_string();
+        return Ok(quote! {
+            include!( #dest );
+        });
+    };
 
-        f.write_all(&mut bytes)?;
-    } // guard implicitly dropped here; now safe to call rustfmt
+    if verbose {
+        eprintln!("expander: writing {}", dest.display());
+    }
+
+    if let Some(comment) = comment.into() {
+        f.write_all(&mut comment.as_bytes())?;
+    }
+
+    f.write_all(&mut bytes)?;
+
+    drop(f); // Release FileGuard lock before rustfmt to prevent Windows file locking issues
 
     if let RustFmt::Yes {
         channel,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,16 +299,35 @@ fn expand_to_file(
             .current_dir(cwd);
 
         let res = process.status();
-        if allow_failure {
-            if let Err(err) = res {
-                eprintln!(
-                    "expander: failed to format file {} due to {}",
-                    dest.display(),
-                    err
-                );
+        match res {
+            Err(err) => {
+                if allow_failure {
+                    eprintln!(
+                        "expander: failed to format file {} due to {}",
+                        dest.display(),
+                        err
+                    );
+                } else {
+                    return Err(err);
+                }
             }
-        } else {
-            res?;
+            Ok(exit_status) => {
+                if !exit_status.success() {
+                    let error = std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!(
+                            "rustfmt failed with exit code {} on file {}",
+                            exit_status.code().unwrap_or(-1),
+                            dest.display()
+                        ),
+                    );
+                    if allow_failure {
+                        eprintln!("expander: {}", error);
+                    } else {
+                        return Err(error);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR incorporates the changes from PR #14 and will need to be rebased if PR #14 is applied first.

1. Changes for rustfmt error handling as per #14
2. Fix to drop FileGuard before calling rustfmt.